### PR TITLE
Allow export param overwrite/add using new event_param

### DIFF
--- a/src/Keboola/SilverpopEx/Silverpop.php
+++ b/src/Keboola/SilverpopEx/Silverpop.php
@@ -76,6 +76,12 @@ class Silverpop
     {
       $this->config['format'] = $ymlConfig['format'];
     }
+    
+    $this->config['param'] = array();
+    if (!empty($ymlConfig['param']))
+    {
+      $this->config['param'] = (array) $ymlConfig['param'];
+    }
 
     // print_r($this->config);
     // exit;
@@ -184,7 +190,7 @@ class Silverpop
 
     foreach ($this->config['lists_to_download'] as $listName => $list)
     {
-      $result = $silverpop->rawRecipientDataExport($list, $this->config['date_from'], $this->config['date_to'], $this->config['format']);
+      $result = $silverpop->rawRecipientDataExport($list, $this->config['date_from'], $this->config['date_to'], $this->config['format'], $this->config['param']);
 
       $this->downloadJob($result, $silverpop, 'events', array($listName, $list));
     }

--- a/src/Keboola/SilverpopEx/Silverpop.php
+++ b/src/Keboola/SilverpopEx/Silverpop.php
@@ -77,10 +77,10 @@ class Silverpop
       $this->config['format'] = $ymlConfig['format'];
     }
     
-    $this->config['param'] = array();
-    if (!empty($ymlConfig['param']))
+    $this->config['event_param'] = array();
+    if (!empty($ymlConfig['event_param']))
     {
-      $this->config['param'] = (array) $ymlConfig['param'];
+      $this->config['event_param'] = (array) $ymlConfig['event_param'];
     }
 
     // print_r($this->config);
@@ -190,7 +190,7 @@ class Silverpop
 
     foreach ($this->config['lists_to_download'] as $listName => $list)
     {
-      $result = $silverpop->rawRecipientDataExport($list, $this->config['date_from'], $this->config['date_to'], $this->config['format'], $this->config['param']);
+      $result = $silverpop->rawRecipientDataExport($list, $this->config['date_from'], $this->config['date_to'], $this->config['format'], $this->config['event_param']);
 
       $this->downloadJob($result, $silverpop, 'events', array($listName, $list));
     }

--- a/src/Keboola/SilverpopEx/Util/EngagePod.php
+++ b/src/Keboola/SilverpopEx/Util/EngagePod.php
@@ -221,7 +221,7 @@ class EngagePod {
     /**
      * Creates job for data extract about events
      */
-    public function rawRecipientDataExport($listId, $dateFrom, $dateTo, $format='CSV') {
+    public function rawRecipientDataExport($listId, $dateFrom, $dateTo, $format='CSV', $param = array()) {
         $formatCode = 0;
         if ($format == 'PIPE')
         {
@@ -232,9 +232,7 @@ class EngagePod {
             $formatCode = 2;
         }
 
-        $data["Envelope"] = array(
-            "Body" => array(
-                "RawRecipientDataExport" => array(
+        $defaultParam = array(
                     "LIST_ID" => $listId,
                     "EVENT_DATE_START" => $dateFrom,
                     "EVENT_DATE_END" => $dateTo,
@@ -247,7 +245,12 @@ class EngagePod {
                     "RETURN_MAILING_NAME" => 1,
                     "MOVE_TO_FTP" => 1,
                     "EXPORT_FORMAT" => $formatCode,
-                ),
+                );
+        $param = array_merge($defatultParam, $param);
+
+        $data["Envelope"] = array(
+            "Body" => array(
+                "RawRecipientDataExport" => $param,
             ),
         );
         $response = $this->_request($data);

--- a/src/Keboola/SilverpopEx/Util/EngagePod.php
+++ b/src/Keboola/SilverpopEx/Util/EngagePod.php
@@ -221,7 +221,7 @@ class EngagePod {
     /**
      * Creates job for data extract about events
      */
-    public function rawRecipientDataExport($listId, $dateFrom, $dateTo, $format='CSV', $param = array()) {
+    public function rawRecipientDataExport($listId, $dateFrom, $dateTo, $format='CSV', $eventParam = array()) {
         $formatCode = 0;
         if ($format == 'PIPE')
         {
@@ -246,11 +246,11 @@ class EngagePod {
                     "MOVE_TO_FTP" => 1,
                     "EXPORT_FORMAT" => $formatCode,
                 );
-        $param = array_merge($defatultParam, $param);
+        $eventParam = array_merge($defatultParam, $eventParam);
 
         $data["Envelope"] = array(
             "Body" => array(
-                "RawRecipientDataExport" => $param,
+                "RawRecipientDataExport" => $eventParam,
             ),
         );
         $response = $this->_request($data);


### PR DESCRIPTION
Optional (array) configuration parameter "event_param" can owerwrite or add any parameter in request.
E.g.:
 "event_param": [
    "ALL_EVENT_TYPES":0,
    "SENT":1
  ],
should owerwrite default ALL_EVENT_TYPES value (1) and add new parameter SENT with value 1.
